### PR TITLE
downoad url was redirecting to https, which breaks the tar command

### DIFF
--- a/TomcatInstall
+++ b/TomcatInstall
@@ -38,7 +38,7 @@ def create(server, session_id, account, app_name, extra_info):
     app = server.create_app(session_id, app_name, 'custom_app_with_port', False, '')
 
     # Download the source code and place it under the webapp directory
-    url = 'http://pub.rwx.gr/webfaction-installers/apache-tomcat-7.0.63.tar.gz'
+    url = 'https://pub.rwx.gr/webfaction-installers/apache-tomcat-7.0.63.tar.gz'
     server.system(session_id, 'curl --silent %s | tar xz --strip 1;' % url)
 
     # Change the default port tomcat is listening to


### PR DESCRIPTION
```
$ curl --silent http://pub.rwx.gr/webfaction-installers/apache-tomcat-7.0.63.tar.gz | tar xz --strip 1
tar: Unrecognized archive format
tar: Error exit delayed from previous errors.

$ curl --silent http://pub.rwx.gr/webfaction-installers/apache-tomcat-7.0.63.tar.gz 
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>302 Found</title>
</head><body>
<h1>Found</h1>
<p>The document has moved <a href="https://pub.rwx.gr/webfaction-installers/apache-tomcat-7.0.63.tar.gz">here</a>.</p>
</body></html>
```